### PR TITLE
fix browse documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Internet Explorer (10+) is only partially supported.
 
 The documentation resides in the [docs](docs) directory, and is built with the Ruby-based [Jekyll](https://jekyllrb.com/) tool.
 
-Browse the [online documentation here.](https://bulma.io/documentation/overview/start/)
+Browse the [online documentation here.](https://bulma.io/documentation/)
 
 ## Related projects
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->
This is a documentation fix.

### Proposed solution
Fix the broken link.

### Tradeoffs
None.

### Testing Done
Clicked link in browser.

### Changelog updated?

No.
